### PR TITLE
Fixes for DragonChunkManager

### DIFF
--- a/src/main/java/chylex/hee/entity/boss/dragon/managers/DragonChunkManager.java
+++ b/src/main/java/chylex/hee/entity/boss/dragon/managers/DragonChunkManager.java
@@ -1,7 +1,5 @@
 package chylex.hee.entity.boss.dragon.managers;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.world.ChunkCoordIntPair;
 import net.minecraft.world.World;
@@ -20,127 +18,100 @@ import chylex.hee.system.savedata.types.DragonSavefile;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 
 public class DragonChunkManager implements LoadingCallback{
-	private static DragonChunkManager instance;
-	
+	private static DragonChunkManager instance = null;
+	private Ticket ticket;
+	private byte timer;
+
 	public static void register(){
 		if (instance != null)throw new RuntimeException("Cannot register DragonChunkManager twice!");
 		instance = new DragonChunkManager();
 		MinecraftForge.EVENT_BUS.register(instance);
 		ForgeChunkManager.setForcedChunkLoadingCallback(HardcoreEnderExpansion.instance,instance);
 	}
-	
+
 	public static void ping(EntityBossDragon dragon){
-		Ticket ticket = instance.ticket;
-		
-		if (ticket == null){
-			ticket = instance.ticket = ForgeChunkManager.requestTicket(HardcoreEnderExpansion.instance,dragon.worldObj,Type.ENTITY);
+		if (instance.ticket == null){
+			instance.ticket = ForgeChunkManager.requestTicket(HardcoreEnderExpansion.instance,dragon.worldObj,Type.ENTITY);
 			Log.debug("Requested chunkloading ticket on dragon load.");
-			
-			if (ticket != null){
-				ticket.bindEntity(dragon);
-				ticket.setChunkListDepth(9);
+
+			if (instance.ticket != null){
+				instance.ticket.bindEntity(dragon);
+				instance.ticket.setChunkListDepth(9);
 			}
 		}
-		
-		if (ticket == null || --instance.timer >= 0)return;
-		
+
+		if (instance.ticket == null || --instance.timer >= 0)return;
+
 		instance.timer = 4;
-		
-		if (dragon.chunkCoordX == instance.prevChunkX && dragon.chunkCoordZ == instance.prevChunkZ)return;
-		
-		instance.prevChunkX = dragon.chunkCoordX;
-		instance.prevChunkZ = dragon.chunkCoordZ;
-		
+
 		Stopwatch.timeAverage("DragonChunkManager - ping update",10);
-		
-		Set<ChunkCoordIntPair> oldChunks = ticket.getChunkList();
-		Set<ChunkCoordIntPair> updatedChunks = new HashSet<>();
-		
+
 		for(int xx = dragon.chunkCoordX-1; xx <= dragon.chunkCoordX+1; xx++){
 			for(int zz = dragon.chunkCoordZ-1; zz <= dragon.chunkCoordZ+1; zz++){
-				updatedChunks.add(new ChunkCoordIntPair(xx,zz));
+				ForgeChunkManager.forceChunk(instance.ticket,new ChunkCoordIntPair(xx,zz));
 			}
 		}
-		
-		Set<ChunkCoordIntPair> toLoad = new HashSet<>();
-		Set<ChunkCoordIntPair> toUnload = new HashSet<>();
-		
-		for(ChunkCoordIntPair pair:updatedChunks){
-			if (!oldChunks.contains(pair))toLoad.add(pair);
-		}
-		
-		for(ChunkCoordIntPair pair:oldChunks){
-			if (!updatedChunks.contains(pair))toUnload.add(pair);
-		}
-		
-		for(ChunkCoordIntPair unload:toUnload)ForgeChunkManager.unforceChunk(ticket,unload);
-		for(ChunkCoordIntPair load:toLoad)ForgeChunkManager.forceChunk(ticket,load);
-		
+
 		Stopwatch.finish("DragonChunkManager - ping update");
 	}
-	
+
 	public static void release(EntityBossDragon dragon){
 		if (instance.ticket == null)return;
-		
+
 		WorldDataHandler.<DragonSavefile>get(DragonSavefile.class).setLastDragonChunk(dragon.chunkCoordX,dragon.chunkCoordZ);
 		ForgeChunkManager.releaseTicket(instance.ticket);
 		instance.ticket = null;
 		instance.clear();
 		Log.debug("Dragon requested releasing the chunkloading ticket.");
 	}
-	
-	private Ticket ticket;
-	private int prevChunkX = Integer.MAX_VALUE, prevChunkZ = Integer.MAX_VALUE;
-	private byte timer;
-	
+
 	@Override
 	public void ticketsLoaded(List<Ticket> tickets, World world){
 		Log.debug("Loaded dragon chunkloading tickets ($0).",tickets.size());
-		
+
 		if (!tickets.isEmpty()){
-			ticket = tickets.get(0);
-			
-			if (ticket.getType() != Type.ENTITY || !(ticket.getEntity() instanceof EntityBossDragon)){
+			instance.ticket = tickets.get(0);
+
+			if (instance.ticket.getType() != Type.ENTITY || !(instance.ticket.getEntity() instanceof EntityBossDragon)){
 				Log.debug("Canceled loaded ticket (invalid).");
-				ticket = null;
+				instance.ticket = null;
 			}
 			else{
-				clear();
-				ping((EntityBossDragon)ticket.getEntity());
+				instance.clear();
+				ping((EntityBossDragon)instance.ticket.getEntity());
 			}
 		}
 	}
-	
+
 	@SubscribeEvent
 	public void onWorldLoad(WorldEvent.Load e){
 		if (!e.world.isRemote && e.world.provider.dimensionId == 1){
 			DragonSavefile file = WorldDataHandler.get(DragonSavefile.class);
 			if (file.isDragonDead())return;
-			
+
 			ChunkCoordIntPair chunk = file.getLastDragonChunk();
 			e.world.getChunkFromChunkCoords(chunk.chunkXPos,chunk.chunkZPos);
-			
+
 			int xx = chunk.chunkXPos*16, zz = chunk.chunkZPos*16;
 			List<EntityBossDragon> list = e.world.getEntitiesWithinAABB(EntityBossDragon.class,AxisAlignedBB.getBoundingBox(xx,-32,zz,xx+16,512,zz+16));
-			
+
 			if (!list.isEmpty()){
 				Log.debug("Loading dragon based on last stored chunk.");
-				clear();
+				instance.clear();
 				ping(list.get(0));
 			}
 		}
 	}
-	
+
 	@SubscribeEvent
 	public void onWorldUnload(WorldEvent.Unload e){
-		if (ticket != null && !e.world.isRemote && e.world.provider.dimensionId == 1){
-			ticket = null;
+		if (instance.ticket != null && !e.world.isRemote && e.world.provider.dimensionId == 1){
+			instance.ticket = null;
 			Log.debug("World unloaded, dereferencing dragon chunkloading ticket.");
 		}
 	}
-	
+
 	private void clear(){
-		timer = 0;
-		prevChunkX = prevChunkZ = Integer.MAX_VALUE;
+		instance.timer = 0;
 	}
 }


### PR DESCRIPTION
Updated references to use singleton instance
Stripped unnecessary code for making expensive checks (every 4 pings) for chunks that need adding or removing from the ForgeChunkManager (ForgeChunkManager will do this anyway) 
ChunkListDepth is currently set to 9 there is a potential case (if loading and unloading chunks is expensive) for increasing this buffer size

[With this attached change my HEE experience went from 5 fps to >30 fps]